### PR TITLE
fix: removed 2 deps that are in LB-Core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Babel==2.9.1
 bleach==4.1.0
 certifi==2022.5.18.1
 charset-normalizer==2.0.7
-click==8.1.3
 colorama==0.4.4
 docopt==0.6.2
 docutils==0.17
@@ -21,7 +20,6 @@ iniconfig==1.1.1
 Jinja2==3.0.3
 keyring==23.2.1
 ladybug-core>=0.39.56
-ladybug-geometry>=1.24.2
 ladybug-geometry-polyskel>=1.3.55
 ladybug-rhino>=1.32.0
 MarkupSafe==2.0.1


### PR DESCRIPTION
Removed the following from requirements.txt as are contained in ladybug-core: which is the overall parent of said dependencies, so the versioning will be handled if changed when dependabot detects ladybug-core updates
```
ladybug-geometry==1.24.2
click==7.1.2
```